### PR TITLE
Make Elmish.Avalonia work on non-Windows systems

### DIFF
--- a/src/Elmish.Avalonia/Command.fs
+++ b/src/Elmish.Avalonia/Command.fs
@@ -19,7 +19,8 @@ type internal Command(execute, canExecute) =
   let mutable _handler = Unchecked.defaultof<EventHandler>
   member this.AddRequeryHandler () =
     let handler = EventHandler(fun _ _ -> this.RaiseCanExecuteChanged())
-    CommandManager.RequerySuggested.AddHandler handler
+    // CommandManager doesn't seem to be available outside of Windows, sample works without it but I suppose I can't just remove it :^)
+    // CommandManager.RequerySuggested.AddHandler handler
     _handler <- handler
 
   member this.RaiseCanExecuteChanged () = canExecuteChanged.Trigger(this, EventArgs.Empty)

--- a/src/Elmish.Avalonia/Elmish.Avalonia.fsproj
+++ b/src/Elmish.Avalonia/Elmish.Avalonia.fsproj
@@ -1,12 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;netcoreapp3.1;net480</TargetFrameworks>
-    <UseWpf>true</UseWpf>
+    <TargetFrameworks>net6.0;netcoreapp3.1;net480</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/Samples/AvaloniaExample/App.axaml.fs
+++ b/src/Samples/AvaloniaExample/App.axaml.fs
@@ -10,7 +10,7 @@ type App() =
 
     override this.Initialize() =
         // Initialize Avalonia controls from NuGet packages:
-        let dataGridType = typeof<System.Windows.Controls.DataGrid>
+        let _ = typeof<Avalonia.Controls.DataGrid>
 
         AvaloniaXamlLoader.Load(this)
 

--- a/src/Samples/AvaloniaExample/AvaloniaExample.fsproj
+++ b/src/Samples/AvaloniaExample/AvaloniaExample.fsproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0-windows</TargetFramework>
-        <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
         <ApplicationManifest>app.manifest</ApplicationManifest>
     </PropertyGroup>
 
@@ -33,7 +32,7 @@
         <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview5" />
         <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview5" />
         <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview5" />
-        <PackageReference Include="Elmish.Avalonia" Version="1.0.0-alpha-2" />
+        <ProjectReference Include="..\..\Elmish.Avalonia\Elmish.Avalonia.fsproj" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     </ItemGroup>
 


### PR DESCRIPTION
So I was trying to test this out on my Mac and I got a bunch of errors related to the project being Windows-only. After playing some hide and seek with the compiler I was able to pin point these changes to make it work on other OSs. I've only tested in Mac, but given that there's no Windows-specific references here it should work just as well on Linux.

The only gap that I wasn't able to fill is the `CommandManager`, since this seems to be on the Windows namespace which is not available outside of Windows. For now I've just removed the reference and the sample seems to work just fine, however I'm guessing that this will cause issues when using something like what's mension on type's docs. I'm not familiar with commanding in WPF, is there some Avalonia alternative for this?

Note: There's no need to merge this if you want to keep it Windows only, just thought it'd be nice to have it for other OSs since it's one of the main advantages of Avalonia vs WPF :^)